### PR TITLE
Bringing the plugin to a working state. 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     `java-library`
     id("org.spongepowered.gradle.plugin") version "2.0.1"
     id("com.github.johnrengelman.shadow") version "4.0.4"
-	id("eclipse")
+    id("eclipse")
     checkstyle
 }
 
@@ -47,7 +47,7 @@ sponge {
         }
         dependency("localeapi") {
             loadOrder(PluginDependency.LoadOrder.AFTER)
-			version("2.1.0")
+            version("2.1.0")
             optional(true)
         }
     }
@@ -67,8 +67,8 @@ tasks.withType(AbstractArchiveTask::class).configureEach {
 
 dependencies {
     implementation("org.mybatis:mybatis:3.5.6")
-	implementation("com.github.SawFowl:LocaleAPI:2.1.0")
-	implementation("mysql:mysql-connector-java:8.0.29")
+    implementation("com.github.SawFowl:LocaleAPI:2.1.0")
+    implementation("mysql:mysql-connector-java:8.0.29")
 
     testImplementation("org.mybatis:mybatis:3.5.6")
     testImplementation("org.spongepowered:spongeapi:8.0.0")
@@ -82,11 +82,20 @@ dependencies {
     testImplementation("org.mockito:mockito-junit-jupiter:3.6.28")
 }
 
+tasks.test {
+    dependsOn("cleanTest")
+
+    useJUnitPlatform()
+    testLogging {
+        events("passed", "skipped", "failed")
+    }
+}
+
 tasks.shadowJar {
     archiveBaseName.set("TotalEconomy")
     dependencies {
-		exclude(dependency("com.github.SawFowl:LocaleAPI:2.1.0"))
-		include(dependency("mysql:mysql-connector-java:8.0.29"))
+	exclude(dependency("com.github.SawFowl:LocaleAPI:2.1.0"))
+	include(dependency("mysql:mysql-connector-java:8.0.29"))
         include(dependency("org.mybatis:mybatis"))
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,8 +94,8 @@ tasks.test {
 tasks.shadowJar {
     archiveBaseName.set("TotalEconomy")
     dependencies {
-	exclude(dependency("com.github.SawFowl:LocaleAPI:2.1.0"))
-	include(dependency("mysql:mysql-connector-java:8.0.29"))
+        exclude(dependency("com.github.SawFowl:LocaleAPI:2.1.0"))
+        include(dependency("mysql:mysql-connector-java:8.0.29"))
         include(dependency("org.mybatis:mybatis"))
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     `java-library`
     id("org.spongepowered.gradle.plugin") version "2.0.1"
     id("com.github.johnrengelman.shadow") version "4.0.4"
+	id("eclipse")
     checkstyle
 }
 
@@ -13,6 +14,9 @@ version = "2.0.0"
 
 repositories {
     mavenCentral()
+	jcenter()
+	maven { url = uri("https://maven.blamejared.com") }
+	maven { url = uri("https://jitpack.io") }
 }
 
 sponge {
@@ -34,9 +38,17 @@ sponge {
         contributor("Eric Grandt") {
             description("Lead Developer")
         }
+        contributor("SawFowl") {
+            description("Various code edits")
+        }
         dependency("spongeapi") {
             loadOrder(PluginDependency.LoadOrder.AFTER)
             optional(false)
+        }
+        dependency("localeapi") {
+            loadOrder(PluginDependency.LoadOrder.AFTER)
+			version("2.1.0")
+            optional(true)
         }
     }
 }
@@ -55,6 +67,8 @@ tasks.withType(AbstractArchiveTask::class).configureEach {
 
 dependencies {
     implementation("org.mybatis:mybatis:3.5.6")
+	implementation("com.github.SawFowl:LocaleAPI:2.1.0")
+	implementation("mysql:mysql-connector-java:8.0.29")
 
     testImplementation("org.mybatis:mybatis:3.5.6")
     testImplementation("org.spongepowered:spongeapi:8.0.0")
@@ -68,18 +82,11 @@ dependencies {
     testImplementation("org.mockito:mockito-junit-jupiter:3.6.28")
 }
 
-tasks.test {
-    dependsOn("cleanTest")
-
-    useJUnitPlatform()
-    testLogging {
-        events("passed", "skipped", "failed")
-    }
-}
-
 tasks.shadowJar {
     archiveBaseName.set("TotalEconomy")
     dependencies {
+		exclude(dependency("com.github.SawFowl:LocaleAPI:2.1.0"))
+		include(dependency("mysql:mysql-connector-java:8.0.29"))
         include(dependency("org.mybatis:mybatis"))
     }
 }

--- a/src/main/java/com/ericgrandt/commands/BalanceAddCommand.java
+++ b/src/main/java/com/ericgrandt/commands/BalanceAddCommand.java
@@ -1,0 +1,131 @@
+package com.ericgrandt.commands;
+
+import com.ericgrandt.TotalEconomy;
+import com.ericgrandt.config.LocalePaths;
+import com.ericgrandt.config.Locales.Placeholders;
+import com.ericgrandt.data.TempData;
+import com.ericgrandt.domain.Balance;
+import com.ericgrandt.domain.TECommandResult;
+import com.ericgrandt.domain.TECurrency;
+import com.ericgrandt.services.AccountService;
+import com.ericgrandt.services.TEEconomyService;
+import com.ericgrandt.wrappers.ParameterWrapper;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandExecutor;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.exception.CommandException;
+import org.spongepowered.api.command.parameter.CommandContext;
+import org.spongepowered.api.command.parameter.Parameter;
+import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.service.economy.Currency;
+import org.spongepowered.api.util.locale.LocaleSource;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+
+public class BalanceAddCommand implements CommandExecutor {
+    private final TEEconomyService economyService;
+    private final AccountService accountService;
+    private final ParameterWrapper parameterWrapper;
+    private final TotalEconomy plugin = TotalEconomy.getInstance();
+
+    public BalanceAddCommand(TEEconomyService economyService, AccountService accountService, ParameterWrapper parameterWrapper) {
+        this.economyService = economyService;
+        this.accountService = accountService;
+        this.parameterWrapper = parameterWrapper;
+    }
+
+    @Override
+    public CommandResult execute(CommandContext context) throws CommandException {
+
+        Optional<User> player = null;
+        try {
+            player = getUserArgument(context);
+        } catch (ExecutionException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        TECurrency currency = getCurrencyArgument(context);
+        BigDecimal amount = getAmountArgument(context);
+        if(!player.isPresent()) {
+            plugin.getDefaultConfiguration().get().writeTempData(getUnknownUserArgument(context), new TempData(currency, amount));
+            throw new CommandException(plugin.getLocales().getText("Account not found. Writing temporary data.", ((LocaleSource) context.cause().root()).locale(), LocalePaths.WRITE_TEMP_DATA));
+        }
+        Balance balance = accountService.getBalance(
+            player.get().uniqueId(),
+            currency.getId()
+        );
+        balance.setBalance(balance.getBalance().add(amount));
+        accountService.getAccountData().setBalance(balance);
+        player.get().player().ifPresent(online -> {
+        	online.sendMessage(plugin.getLocales().getTextWhithReplacers("&aYour balance in the currency &6" + Placeholders.CURRENCY + " &ais increased by &6" + Placeholders.CURRENCY + Placeholders.VALUE + "&a. Current balance&f: &6" + Placeholders.CURRENCY + Placeholders.BALANCE + "&a.", online.locale(), plugin.getLocales().createReplaceMap(Arrays.asList(Placeholders.CURRENCY, Placeholders.VALUE, Placeholders.BALANCE), Arrays.asList(toPlain(currency.symbol()), amount.doubleValue(), balance.getBalance().doubleValue())), LocalePaths.BALANCE_ADD));
+        });
+        context.cause().audience().sendMessage(plugin.getLocales().getTextWhithReplacers("&aThe balance of the player &6" + Placeholders.PLAYER + " &aincreased by &6" + Placeholders.CURRENCY + Placeholders.VALUE + "&a. Current balance&f: &6" + Placeholders.CURRENCY + Placeholders.BALANCE + "&a.", ((LocaleSource) context.cause().root()).locale(), plugin.getLocales().createReplaceMap(Arrays.asList(Placeholders.PLAYER, Placeholders.CURRENCY, Placeholders.VALUE, Placeholders.BALANCE), Arrays.asList(player.get().name(), toPlain(currency.symbol()), amount.doubleValue(), balance.getBalance().doubleValue())), LocalePaths.BALANCE_ADD_ADMIN));
+        /*context.cause().audience().sendMessage(
+            Component.text("New balance: ", NamedTextColor.GRAY)
+                .append(
+                    currency.format(balance.getBalance()).color(NamedTextColor.GOLD)
+                )
+        );
+*/
+        return new TECommandResult(true);
+    }
+
+    private TECurrency getCurrencyArgument(CommandContext context) throws CommandException {
+        Parameter.Key<String> currencyKey = parameterWrapper.key("currency", String.class);
+        Optional<String> currencyParamOpt = context.one(currencyKey);
+        if (currencyParamOpt.isPresent()) {
+            Optional<Currency> currencyOpt = economyService.currencies().stream().filter(c ->
+                PlainTextComponentSerializer.plainText().serialize(c.displayName()).equals(currencyParamOpt.get())
+            ).findFirst();
+
+            if (currencyOpt.isPresent()) {
+                return (TECurrency) currencyOpt.get();
+            } else {
+                throw new CommandException(Component.text("That currency does not exist"));
+            }
+        }
+
+        return (TECurrency) economyService.defaultCurrency();
+    }
+
+    private BigDecimal getAmountArgument(CommandContext context) throws CommandException {
+        Parameter.Key<BigDecimal> amountKey = parameterWrapper.key("amount", BigDecimal.class);
+        Optional<BigDecimal> amountOpt = context.one(amountKey);
+        if (!amountOpt.isPresent()) {
+            throw new CommandException(Component.text("Amount argument is missing"));
+        } else if (!(amountOpt.get().compareTo(BigDecimal.ZERO) > 0)) {
+            throw new CommandException(Component.text("Amount must be greater than 0"));
+        }
+
+        return amountOpt.get();
+    }
+
+    private Optional<User> getUserArgument(CommandContext context) throws CommandException, ExecutionException, InterruptedException {
+        Parameter.Key<String> playerKey = parameterWrapper.key("player", String.class);
+        Optional<String> toUserOpt = context.one(playerKey);
+        if (!toUserOpt.isPresent()) {
+            throw new CommandException(Component.text("Player argument is missing"));
+        }
+
+        return Sponge.server().userManager().load(toUserOpt.get()).get();
+    }
+
+    private String getUnknownUserArgument(CommandContext context) throws CommandException {
+        Parameter.Key<String> playerKey = parameterWrapper.key("player", String.class);
+        Optional<String> toUserOpt = context.one(playerKey);
+        if (!toUserOpt.isPresent()) {
+            throw new CommandException(Component.text("Player argument is missing"));
+        }
+        return toUserOpt.get();
+    }
+
+    private String toPlain(Component component) {
+    	return LegacyComponentSerializer.legacyAmpersand().serialize(component);
+    }
+}

--- a/src/main/java/com/ericgrandt/commands/BalanceAddCommand.java
+++ b/src/main/java/com/ericgrandt/commands/BalanceAddCommand.java
@@ -87,7 +87,7 @@ public class BalanceAddCommand implements CommandExecutor {
             if (currencyOpt.isPresent()) {
                 return (TECurrency) currencyOpt.get();
             } else {
-                throw new CommandException(Component.text("That currency does not exist"));
+                throw new CommandException(plugin.getLocales().getText("That currency does not exist", ((LocaleSource) context.cause().root()).locale(), LocalePaths.CURRENCY_NOT_EXIST));
             }
         }
 
@@ -98,29 +98,23 @@ public class BalanceAddCommand implements CommandExecutor {
         Parameter.Key<BigDecimal> amountKey = parameterWrapper.key("amount", BigDecimal.class);
         Optional<BigDecimal> amountOpt = context.one(amountKey);
         if (!amountOpt.isPresent()) {
-            throw new CommandException(Component.text("Amount argument is missing"));
+            throw new CommandException(plugin.getLocales().getText("Amount argument is missing.", ((LocaleSource) context.cause().root()).locale(), LocalePaths.PAY_MISSING_AMOUNT));
         } else if (!(amountOpt.get().compareTo(BigDecimal.ZERO) > 0)) {
-            throw new CommandException(Component.text("Amount must be greater than 0"));
+            throw new CommandException(plugin.getLocales().getText("Amount must be greater than 0.", ((LocaleSource) context.cause().root()).locale(), LocalePaths.PAY_ZERO_OR_BELOW));
         }
 
         return amountOpt.get();
     }
 
     private Optional<User> getUserArgument(CommandContext context) throws CommandException, ExecutionException, InterruptedException {
-        Parameter.Key<String> playerKey = parameterWrapper.key("player", String.class);
-        Optional<String> toUserOpt = context.one(playerKey);
-        if (!toUserOpt.isPresent()) {
-            throw new CommandException(Component.text("Player argument is missing"));
-        }
-
-        return Sponge.server().userManager().load(toUserOpt.get()).get();
+        return Sponge.server().userManager().load(getUnknownUserArgument(context)).get();
     }
 
     private String getUnknownUserArgument(CommandContext context) throws CommandException {
         Parameter.Key<String> playerKey = parameterWrapper.key("player", String.class);
         Optional<String> toUserOpt = context.one(playerKey);
         if (!toUserOpt.isPresent()) {
-            throw new CommandException(Component.text("Player argument is missing"));
+            throw new CommandException(plugin.getLocales().getText("Player argument is missing.", ((LocaleSource) context.cause().root()).locale(), LocalePaths.PLAYER_MISSING));
         }
         return toUserOpt.get();
     }

--- a/src/main/java/com/ericgrandt/commands/BalanceRemoveCommand.java
+++ b/src/main/java/com/ericgrandt/commands/BalanceRemoveCommand.java
@@ -1,0 +1,125 @@
+package com.ericgrandt.commands;
+
+import com.ericgrandt.TotalEconomy;
+import com.ericgrandt.config.LocalePaths;
+import com.ericgrandt.config.Locales.Placeholders;
+import com.ericgrandt.data.TempData;
+import com.ericgrandt.domain.Balance;
+import com.ericgrandt.domain.TECommandResult;
+import com.ericgrandt.domain.TECurrency;
+import com.ericgrandt.services.AccountService;
+import com.ericgrandt.services.TEEconomyService;
+import com.ericgrandt.wrappers.ParameterWrapper;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandExecutor;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.exception.CommandException;
+import org.spongepowered.api.command.parameter.CommandContext;
+import org.spongepowered.api.command.parameter.Parameter;
+import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.service.economy.Currency;
+import org.spongepowered.api.util.locale.LocaleSource;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+
+public class BalanceRemoveCommand implements CommandExecutor {
+    private final TEEconomyService economyService;
+    private final AccountService accountService;
+    private final ParameterWrapper parameterWrapper;
+    private final TotalEconomy plugin = TotalEconomy.getInstance();
+
+    public BalanceRemoveCommand(TEEconomyService economyService, AccountService accountService, ParameterWrapper parameterWrapper) {
+        this.economyService = economyService;
+        this.accountService = accountService;
+        this.parameterWrapper = parameterWrapper;
+    }
+
+    @Override
+    public CommandResult execute(CommandContext context) throws CommandException {
+
+        Optional<User> player = null;
+        try {
+            player = getUserArgument(context);
+        } catch (ExecutionException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        TECurrency currency = getCurrencyArgument(context);
+        BigDecimal amount = getAmountArgument(context);
+        if(!player.isPresent()) {
+            throw new CommandException(plugin.getLocales().getText("Failed to run command: invalid account(s).", ((LocaleSource) context.cause().root()).locale(), LocalePaths.INVALID_ACCOUNT));
+        }
+        Balance balance = accountService.getBalance(
+            player.get().uniqueId(),
+            currency.getId()
+        );
+        if(balance.getBalance().subtract(amount).doubleValue() < 0) {
+            balance.setBalance(BigDecimal.ZERO);
+        } else {
+            balance.setBalance(balance.getBalance().subtract(amount));
+        }
+        accountService.getAccountData().setBalance(balance);
+        player.get().player().ifPresent(online -> {
+        	online.sendMessage(plugin.getLocales().getTextWhithReplacers("&aYour balance in the currency &6" + Placeholders.CURRENCY + " &ais reduced by &6" + Placeholders.CURRENCY + Placeholders.VALUE + "&a. Current balance&f: &6" + Placeholders.CURRENCY + Placeholders.BALANCE + "&a.", online.locale(), plugin.getLocales().createReplaceMap(Arrays.asList(Placeholders.CURRENCY, Placeholders.VALUE, Placeholders.BALANCE), Arrays.asList(toPlain(currency.symbol()), amount.doubleValue(), balance.getBalance().doubleValue())), LocalePaths.BALANCE_REMOVE));
+        });
+        context.cause().audience().sendMessage(plugin.getLocales().getTextWhithReplacers("&aThe balance of the player &6" + Placeholders.PLAYER + " &areduced by &6" + Placeholders.CURRENCY + Placeholders.VALUE + "&a. Current balance&f: &6" + Placeholders.CURRENCY + Placeholders.BALANCE + "&a.", ((LocaleSource) context.cause().root()).locale(), plugin.getLocales().createReplaceMap(Arrays.asList(Placeholders.PLAYER, Placeholders.CURRENCY, Placeholders.VALUE, Placeholders.BALANCE), Arrays.asList(player.get().name(), toPlain(currency.symbol()), amount.doubleValue(), balance.getBalance().doubleValue())), LocalePaths.BALANCE_REMOVE_ADMIN));
+/*         context.cause().audience().sendMessage(
+            Component.text("New balance: ", NamedTextColor.GRAY)
+                .append(
+                    currency.format(balance.getBalance()).color(NamedTextColor.GOLD)
+                )
+        );
+*/
+        return new TECommandResult(true);
+    }
+
+    private TECurrency getCurrencyArgument(CommandContext context) throws CommandException {
+        Parameter.Key<String> currencyKey = parameterWrapper.key("currency", String.class);
+        Optional<String> currencyParamOpt = context.one(currencyKey);
+        if (currencyParamOpt.isPresent()) {
+            Optional<Currency> currencyOpt = economyService.currencies().stream().filter(c ->
+                PlainTextComponentSerializer.plainText().serialize(c.displayName()).equals(currencyParamOpt.get())
+            ).findFirst();
+
+            if (currencyOpt.isPresent()) {
+                return (TECurrency) currencyOpt.get();
+            } else {
+                throw new CommandException(plugin.getLocales().getText("That currency does not exist.", ((LocaleSource) context.cause().root()).locale(), LocalePaths.CURRENCY_NOT_EXIST));
+            }
+        }
+
+        return (TECurrency) economyService.defaultCurrency();
+    }
+
+    private BigDecimal getAmountArgument(CommandContext context) throws CommandException {
+        Parameter.Key<BigDecimal> amountKey = parameterWrapper.key("amount", BigDecimal.class);
+        Optional<BigDecimal> amountOpt = context.one(amountKey);
+        if (!amountOpt.isPresent()) {
+            throw new CommandException(plugin.getLocales().getText("Amount argument is missing.", ((LocaleSource) context.cause().root()).locale(), LocalePaths.PAY_MISSING_AMOUNT));
+        } else if (!(amountOpt.get().compareTo(BigDecimal.ZERO) > 0)) {
+            throw new CommandException(plugin.getLocales().getText("Amount must be greater than 0.", ((LocaleSource) context.cause().root()).locale(), LocalePaths.PAY_ZERO_OR_BELOW));
+        }
+
+        return amountOpt.get();
+    }
+
+    private Optional<User> getUserArgument(CommandContext context) throws CommandException, ExecutionException, InterruptedException {
+        Parameter.Key<String> playerKey = parameterWrapper.key("player", String.class);
+        Optional<String> toUserOpt = context.one(playerKey);
+        if (!toUserOpt.isPresent()) {
+            throw new CommandException(plugin.getLocales().getText("Player argument is missing.", ((LocaleSource) context.cause().root()).locale(), LocalePaths.PLAYER_MISSING));
+        }
+
+        return Sponge.server().userManager().load(toUserOpt.get()).get();
+    }
+
+    private String toPlain(Component component) {
+    	return LegacyComponentSerializer.legacyAmpersand().serialize(component);
+    }
+}

--- a/src/main/java/com/ericgrandt/commands/BalanceSetCommand.java
+++ b/src/main/java/com/ericgrandt/commands/BalanceSetCommand.java
@@ -1,0 +1,119 @@
+package com.ericgrandt.commands;
+
+import com.ericgrandt.TotalEconomy;
+import com.ericgrandt.config.LocalePaths;
+import com.ericgrandt.config.Locales.Placeholders;
+import com.ericgrandt.domain.Balance;
+import com.ericgrandt.domain.TECommandResult;
+import com.ericgrandt.domain.TECurrency;
+import com.ericgrandt.services.AccountService;
+import com.ericgrandt.services.TEEconomyService;
+import com.ericgrandt.wrappers.ParameterWrapper;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandExecutor;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.exception.CommandException;
+import org.spongepowered.api.command.parameter.CommandContext;
+import org.spongepowered.api.command.parameter.Parameter;
+import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.service.economy.Currency;
+import org.spongepowered.api.util.locale.LocaleSource;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+
+public class BalanceSetCommand implements CommandExecutor {
+    private final TEEconomyService economyService;
+    private final AccountService accountService;
+    private final ParameterWrapper parameterWrapper;
+    private final TotalEconomy plugin = TotalEconomy.getInstance();
+
+    public BalanceSetCommand(TEEconomyService economyService, AccountService accountService, ParameterWrapper parameterWrapper) {
+        this.economyService = economyService;
+        this.accountService = accountService;
+        this.parameterWrapper = parameterWrapper;
+    }
+
+    @Override
+    public CommandResult execute(CommandContext context) throws CommandException {
+
+        Optional<User> player = null;
+        try {
+            player = getUserArgument(context);
+        } catch (ExecutionException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        TECurrency currency = getCurrencyArgument(context);
+        BigDecimal amount = getAmountArgument(context);
+        if(!player.isPresent()) {
+            throw new CommandException(plugin.getLocales().getText("Failed to run command: invalid account(s).", ((LocaleSource) context.cause().root()).locale(), LocalePaths.INVALID_ACCOUNT));
+        }
+        Balance balance = accountService.getBalance(
+            player.get().uniqueId(),
+            currency.getId()
+        );
+        balance.setBalance(amount);
+        accountService.getAccountData().setBalance(balance);
+        player.get().player().ifPresent(online -> {
+        	online.sendMessage(plugin.getLocales().getTextWhithReplacers("&aYour balance in the currency &6" + Placeholders.CURRENCY + " &ais set to &6" + Placeholders.CURRENCY + Placeholders.BALANCE + "&a.", online.locale(), plugin.getLocales().createReplaceMap(Arrays.asList(Placeholders.CURRENCY, Placeholders.BALANCE), Arrays.asList(toPlain(currency.symbol()), balance.getBalance().doubleValue())), LocalePaths.BALANCE_SET));
+        });
+        context.cause().audience().sendMessage(plugin.getLocales().getTextWhithReplacers("&aThe balance of the player &6" + Placeholders.PLAYER + " &aset to &6" + Placeholders.CURRENCY + Placeholders.BALANCE + "&a.", ((LocaleSource) context.cause().root()).locale(), plugin.getLocales().createReplaceMap(Arrays.asList(Placeholders.PLAYER, Placeholders.CURRENCY, Placeholders.BALANCE), Arrays.asList(player.get().name(), toPlain(currency.symbol()), balance.getBalance().doubleValue())), LocalePaths.BALANCE_SET_ADMIN));
+/*        context.cause().audience().sendMessage(
+            Component.text("New balance: ", NamedTextColor.GRAY)
+                .append(
+                    currency.format(balance.getBalance()).color(NamedTextColor.GOLD)
+                )
+        );
+*/
+        return new TECommandResult(true);
+    }
+
+    private TECurrency getCurrencyArgument(CommandContext context) throws CommandException {
+        Parameter.Key<String> currencyKey = parameterWrapper.key("currency", String.class);
+        Optional<String> currencyParamOpt = context.one(currencyKey);
+        if (currencyParamOpt.isPresent()) {
+            Optional<Currency> currencyOpt = economyService.currencies().stream().filter(c ->
+                PlainTextComponentSerializer.plainText().serialize(c.displayName()).equals(currencyParamOpt.get())
+            ).findFirst();
+
+            if (currencyOpt.isPresent()) {
+                return (TECurrency) currencyOpt.get();
+            } else {
+                throw new CommandException(plugin.getLocales().getText("That currency does not exist.", ((LocaleSource) context.cause().root()).locale(), LocalePaths.CURRENCY_NOT_EXIST));
+            }
+        }
+
+        return (TECurrency) economyService.defaultCurrency();
+    }
+
+    private BigDecimal getAmountArgument(CommandContext context) throws CommandException {
+        Parameter.Key<BigDecimal> amountKey = parameterWrapper.key("amount", BigDecimal.class);
+        Optional<BigDecimal> amountOpt = context.one(amountKey);
+        if (!amountOpt.isPresent()) {
+            throw new CommandException(plugin.getLocales().getText("Amount argument is missing.", ((LocaleSource) context.cause().root()).locale(), LocalePaths.PAY_MISSING_AMOUNT));
+        } else if (!(amountOpt.get().compareTo(BigDecimal.ZERO) > 0)) {
+            throw new CommandException(plugin.getLocales().getText("Amount must be greater than 0.", ((LocaleSource) context.cause().root()).locale(), LocalePaths.PAY_ZERO_OR_BELOW));
+        }
+
+        return amountOpt.get();
+    }
+
+    private Optional<User> getUserArgument(CommandContext context) throws CommandException, ExecutionException, InterruptedException {
+        Parameter.Key<String> playerKey = parameterWrapper.key("player", String.class);
+        Optional<String> toUserOpt = context.one(playerKey);
+        if (!toUserOpt.isPresent()) {
+            throw new CommandException(plugin.getLocales().getText("Player argument is missing.", ((LocaleSource) context.cause().root()).locale(), LocalePaths.PLAYER_MISSING));
+        }
+
+        return Sponge.server().userManager().load(toUserOpt.get()).get();
+    }
+
+    private String toPlain(Component component) {
+    	return LegacyComponentSerializer.legacyAmpersand().serialize(component);
+    }
+}

--- a/src/main/java/com/ericgrandt/commands/CommandRegister.java
+++ b/src/main/java/com/ericgrandt/commands/CommandRegister.java
@@ -35,6 +35,9 @@ public class CommandRegister {
     public void registerCommands(final RegisterCommandEvent<Command.Parameterized> event) {
         registerBalanceCommand(event);
         registerPayCommand(event);
+        registerAddMoney(event);
+        registerRemoveMoney(event);
+        registerSetMoney(event);
     }
 
     void registerBalanceCommand(final RegisterCommandEvent<Command.Parameterized> event) {
@@ -49,24 +52,79 @@ public class CommandRegister {
         event.register(
             plugin,
             command,
-            "balance"
+            "balance", "money"
         );
     }
 
     void registerPayCommand(final RegisterCommandEvent<Command.Parameterized> event) {
         Parameter.Value<ServerPlayer> playerParameter = parameterWrapper.player().key("player").build();
         Parameter.Value<BigDecimal> amountParameter = parameterWrapper.bigDecimal().key("amount").build();
+        Parameter.Value<String> currencyParameter = parameterWrapper.currency().key("currency").optional().build();
 
         Command.Parameterized command = commandBuilder.getBuilder()
             .executor(new PayCommand(economyService, accountService, parameterWrapper))
             .permission("totaleconomy.command.pay")
-            .addParameters(playerParameter, amountParameter)
+            .addParameters(playerParameter, amountParameter, currencyParameter)
             .build();
 
         event.register(
             plugin,
             command,
             "pay"
+        );
+    }
+
+    void registerAddMoney(final RegisterCommandEvent<Command.Parameterized> event) {
+        Parameter.Value<String> playerParameter = parameterWrapper.user().key("player").build();
+        Parameter.Value<String> currencyParameter = parameterWrapper.currency().key("currency").optional().build();
+        Parameter.Value<BigDecimal> amountParameter = parameterWrapper.bigDecimal().key("amount").build();
+
+        Command.Parameterized command = commandBuilder.getBuilder()
+                .executor(new BalanceAddCommand(economyService, accountService, parameterWrapper))
+                .permission("totaleconomy.command.addmoney")
+                .addParameters(playerParameter, amountParameter, currencyParameter)
+                .build();
+
+        event.register(
+                plugin,
+                command,
+                "addmoney", "givemoney", "balanceadd", "balancegive"
+        );
+    }
+
+    void registerRemoveMoney(final RegisterCommandEvent<Command.Parameterized> event) {
+        Parameter.Value<String> playerParameter = parameterWrapper.user().key("player").build();
+        Parameter.Value<String> currencyParameter = parameterWrapper.currency().key("currency").optional().build();
+        Parameter.Value<BigDecimal> amountParameter = parameterWrapper.bigDecimal().key("amount").build();
+
+        Command.Parameterized command = commandBuilder.getBuilder()
+                .executor(new BalanceRemoveCommand(economyService, accountService, parameterWrapper))
+                .permission("totaleconomy.command.removemoney")
+                .addParameters(playerParameter, amountParameter, currencyParameter)
+                .build();
+
+        event.register(
+                plugin,
+                command,
+                "removemoney", "takemoney", "balanceremove", "balancetake"
+        );
+    }
+
+    void registerSetMoney(final RegisterCommandEvent<Command.Parameterized> event) {
+        Parameter.Value<String> playerParameter = parameterWrapper.user().key("player").build();
+        Parameter.Value<String> currencyParameter = parameterWrapper.currency().key("currency").optional().build();
+        Parameter.Value<BigDecimal> amountParameter = parameterWrapper.bigDecimal().key("amount").build();
+
+        Command.Parameterized command = commandBuilder.getBuilder()
+                .executor(new BalanceSetCommand(economyService, accountService, parameterWrapper))
+                .permission("totaleconomy.command.setmoney")
+                .addParameters(playerParameter, amountParameter, currencyParameter)
+                .build();
+
+        event.register(
+                plugin,
+                command,
+                "setmoney", "setbalance"
         );
     }
 }

--- a/src/main/java/com/ericgrandt/commands/PayCommand.java
+++ b/src/main/java/com/ericgrandt/commands/PayCommand.java
@@ -1,7 +1,10 @@
 package com.ericgrandt.commands;
 
+import com.ericgrandt.TotalEconomy;
 import com.ericgrandt.commands.models.PayCommandAccounts;
 import com.ericgrandt.commands.models.PayCommandPlayers;
+import com.ericgrandt.config.LocalePaths;
+import com.ericgrandt.config.Locales.Placeholders;
 import com.ericgrandt.domain.Balance;
 import com.ericgrandt.domain.TEAccount;
 import com.ericgrandt.domain.TECommandResult;
@@ -10,8 +13,12 @@ import com.ericgrandt.services.AccountService;
 import com.ericgrandt.services.TEEconomyService;
 import com.ericgrandt.wrappers.ParameterWrapper;
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.Optional;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+
 import org.spongepowered.api.command.CommandExecutor;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.exception.CommandException;
@@ -20,11 +27,14 @@ import org.spongepowered.api.command.parameter.Parameter;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.living.player.server.ServerPlayer;
 import org.spongepowered.api.event.Cause;
+import org.spongepowered.api.service.economy.Currency;
+import org.spongepowered.api.util.locale.LocaleSource;
 
 public class PayCommand implements CommandExecutor {
     private final TEEconomyService economyService;
     private final AccountService accountService;
     private final ParameterWrapper parameterWrapper;
+    private final TotalEconomy plugin = TotalEconomy.getInstance();
 
     public PayCommand(TEEconomyService economyService, AccountService accountService, ParameterWrapper parameterWrapper) {
         this.economyService = economyService;
@@ -35,15 +45,19 @@ public class PayCommand implements CommandExecutor {
     @Override
     public CommandResult execute(CommandContext context) throws CommandException {
         if (!(context.cause().root() instanceof Player)) {
-            throw new CommandException(Component.text("Only players can use this command"));
+            throw new CommandException(plugin.getLocales().getText("Only players can use this command", ((LocaleSource) context.cause().root()).locale(), LocalePaths.ONLY_PLAYER));
         }
 
         BigDecimal amount = getAmountArgument(context);
         PayCommandAccounts accounts = getAccounts(context);
-        if (!isTransferSuccessful(accounts, amount, context.contextCause())) {
-            throw new CommandException(Component.text("Failed to run command: unable to set balances"));
+        if (!isTransferSuccessful(context, accounts, amount, context.contextCause())) {
+            throw new CommandException(plugin.getLocales().getText("Failed to run command: unable to set balances", ((LocaleSource) context.cause().root()).locale(), LocalePaths.PAY_FAIL));
         }
-
+        Currency currency = getCurrencyArgument(context);
+        Player sender = (Player) context.cause().root();
+        Player recipient = getPlayerArgument(context);
+        sender.sendMessage(plugin.getLocales().getTextWhithReplacers("&aYou have sent &6" + Placeholders.CURRENCY + Placeholders.VALUE + " &ato &6" + Placeholders.PLAYER + "&a.", sender.locale(), plugin.getLocales().createReplaceMap(Arrays.asList(Placeholders.CURRENCY, Placeholders.VALUE, Placeholders.PLAYER), Arrays.asList(toPlain(currency.symbol()), amount.doubleValue(), recipient.name())), LocalePaths.PAY_SENDER));
+        recipient.sendMessage(plugin.getLocales().getTextWhithReplacers("&aYou have received &6" + Placeholders.CURRENCY + Placeholders.VALUE + " &afrom  &6" + Placeholders.PLAYER + "&a.", recipient.locale(), plugin.getLocales().createReplaceMap(Arrays.asList(Placeholders.CURRENCY, Placeholders.VALUE, Placeholders.PLAYER), Arrays.asList(toPlain(currency.symbol()), amount.doubleValue(), sender.name())), LocalePaths.PAY_RECIPIENT));
         return new TECommandResult(true);
     }
 
@@ -51,9 +65,9 @@ public class PayCommand implements CommandExecutor {
         Parameter.Key<BigDecimal> amountKey = parameterWrapper.key("amount", BigDecimal.class);
         Optional<BigDecimal> amountOpt = context.one(amountKey);
         if (!amountOpt.isPresent()) {
-            throw new CommandException(Component.text("Amount argument is missing"));
+            throw new CommandException(plugin.getLocales().getText("Amount argument is missing", ((LocaleSource) context.cause().root()).locale(), LocalePaths.PAY_MISSING_AMOUNT));
         } else if (!(amountOpt.get().compareTo(BigDecimal.ZERO) > 0)) {
-            throw new CommandException(Component.text("Amount must be greater than 0"));
+            throw new CommandException(plugin.getLocales().getText("Amount must be greater than 0", ((LocaleSource) context.cause().root()).locale(), LocalePaths.PAY_ZERO_OR_BELOW));
         }
 
         return amountOpt.get();
@@ -64,7 +78,7 @@ public class PayCommand implements CommandExecutor {
         TEAccount fromAccount = (TEAccount) economyService.findOrCreateAccount(players.getFromPlayer().uniqueId()).orElse(null);
         TEAccount toAccount = (TEAccount) economyService.findOrCreateAccount(players.getToPlayer().uniqueId()).orElse(null);
         if (fromAccount == null || toAccount == null) {
-            throw new CommandException(Component.text("Failed to run command: invalid account(s)"));
+            throw new CommandException(plugin.getLocales().getText("Failed to run command: invalid account(s)", ((LocaleSource) context.cause().root()).locale(), LocalePaths.INVALID_ACCOUNT));
         }
 
         return new PayCommandAccounts(fromAccount, toAccount);
@@ -74,7 +88,7 @@ public class PayCommand implements CommandExecutor {
         Player fromPlayer = (Player) context.cause().root();
         Player toPlayer = getPlayerArgument(context);
         if (toPlayer.uniqueId() == fromPlayer.uniqueId()) {
-            throw new CommandException(Component.text("You cannot pay yourself"));
+            throw new CommandException(plugin.getLocales().getText("You cannot pay yourself", ((LocaleSource) context.cause().root()).locale(), LocalePaths.PAY_SELF));
         }
 
         return new PayCommandPlayers(fromPlayer, toPlayer);
@@ -84,29 +98,49 @@ public class PayCommand implements CommandExecutor {
         Parameter.Key<ServerPlayer> playerKey = parameterWrapper.key("player", ServerPlayer.class);
         Optional<ServerPlayer> toPlayerOpt = context.one(playerKey);
         if (!toPlayerOpt.isPresent()) {
-            throw new CommandException(Component.text("Player argument is missing"));
+            throw new CommandException(plugin.getLocales().getText("Player argument is missing", ((LocaleSource) context.cause().root()).locale(), LocalePaths.PLAYER_MISSING));
         }
 
         return toPlayerOpt.get();
     }
 
-    private boolean isTransferSuccessful(PayCommandAccounts accounts, BigDecimal amount, Cause cause) {
-        TECurrency defaultCurrency = (TECurrency) economyService.defaultCurrency();
+    private boolean isTransferSuccessful(CommandContext context, PayCommandAccounts accounts, BigDecimal amount, Cause cause) {
+        TECurrency currency = getCurrencyArgument(context);
         TEAccount fromAccount = accounts.getFromAccount();
         TEAccount toAccount = accounts.getToAccount();
-        fromAccount.transfer(toAccount, defaultCurrency, amount, (Cause) null);
+        fromAccount.transfer(toAccount, currency, amount, (Cause) null);
 
         Balance fromBalance = new Balance(
             fromAccount.uniqueId(),
-            defaultCurrency.getId(),
-            fromAccount.balance(defaultCurrency, cause)
+            currency.getId(),
+            fromAccount.balance(currency, cause)
         );
         Balance toBalance = new Balance(
             toAccount.uniqueId(),
-            defaultCurrency.getId(),
-            toAccount.balance(defaultCurrency, cause)
+            currency.getId(),
+            toAccount.balance(currency, cause)
         );
 
         return accountService.setTransferBalances(fromBalance, toBalance);
+    }
+
+    private TECurrency getCurrencyArgument(CommandContext context) {
+        Parameter.Key<String> currencyKey = parameterWrapper.key("currency", String.class);
+        Optional<String> currencyParamOpt = context.one(currencyKey);
+        if (currencyParamOpt.isPresent()) {
+            Optional<Currency> currencyOpt = economyService.currencies().stream().filter(c ->
+                PlainTextComponentSerializer.plainText().serialize(c.displayName()).equals(currencyParamOpt.get())
+            ).findFirst();
+
+            if (currencyOpt.isPresent()) {
+                return (TECurrency) currencyOpt.get();
+            }
+        }
+
+        return (TECurrency) economyService.defaultCurrency();
+    }
+   
+    private String toPlain(Component component) {
+    	return LegacyComponentSerializer.legacyAmpersand().serialize(component);
     }
 }

--- a/src/main/java/com/ericgrandt/config/DefaultConfiguration.java
+++ b/src/main/java/com/ericgrandt/config/DefaultConfiguration.java
@@ -1,12 +1,18 @@
 package com.ericgrandt.config;
 
+import com.ericgrandt.TotalEconomy;
+import com.ericgrandt.data.TempData;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 import org.spongepowered.configurate.objectmapping.meta.Setting;
+
+import java.util.*;
 
 @ConfigSerializable
 public class DefaultConfiguration {
     @Setting("database")
     private final DatabaseSettings databaseSettings = new DatabaseSettings();
+    @Setting("tempdata")
+    private final Map<String, List<TempData>> tempData = new HashMap<String, List<TempData>>();
 
     public String getConnectionString() {
         return String.format(
@@ -15,5 +21,48 @@ public class DefaultConfiguration {
             databaseSettings.getUser(),
             databaseSettings.getPassword()
         );
+    }
+
+    public void writeTempData(String player, TempData tempData) {
+        if(!this.tempData.containsKey(player)) {
+            List<TempData> list = new ArrayList<TempData>();
+            list.add(tempData);
+            this.tempData.put(player,list);
+        } else {
+            if(this.tempData.get(player).contains(tempData)) {
+                this.tempData.get(player).stream().filter(temp -> (temp.equals(tempData))).findFirst().ifPresent(temp -> {
+                    temp.update(tempData.getAmount());
+                });
+            } else {
+                this.tempData.get(player).add(tempData);
+            }
+        }
+        TotalEconomy.getInstance().getDefaultConfiguration().setAndSave(this);
+    }
+
+    public Optional<List<TempData>> getTempData(String player) {
+        return Optional.ofNullable(tempData.getOrDefault(player, null));
+    }
+
+    public void checkExpires() {
+        if(this.tempData.isEmpty()) return;;
+        Map<String, List<TempData>> toRemove = new HashMap<String, List<TempData>>();
+        boolean changed = false;
+        for(Map.Entry<String, List<TempData>> entry : this.tempData.entrySet()) {
+            for(TempData temp : entry.getValue()) {
+                if(temp.isExpire()) {
+                    if(!toRemove.containsKey(entry.getKey())) {
+                        toRemove.put(entry.getKey(), new ArrayList<TempData>());
+                    }
+                    toRemove.get(entry.getKey()).add(temp);
+                    changed = true;
+                }
+            }
+        }
+        for(Map.Entry<String, List<TempData>> entry : toRemove.entrySet()) {
+            tempData.get(entry.getKey()).removeAll(entry.getValue());
+            if(tempData.get(entry.getKey()).isEmpty()) tempData.remove(entry.getKey());
+        }
+        if(changed) TotalEconomy.getInstance().getDefaultConfiguration().setAndSave(this);
     }
 }

--- a/src/main/java/com/ericgrandt/config/LocalePaths.java
+++ b/src/main/java/com/ericgrandt/config/LocalePaths.java
@@ -1,0 +1,24 @@
+package com.ericgrandt.config;
+
+public class LocalePaths {
+
+	public static final Object[] ONLY_PLAYER = {"OnlyPlayer"};
+	public static final Object[] PLAYER_MISSING = {"PlayerMissing"};
+	public static final Object[] CURRENCY_NOT_EXIST = {"CurrencyNotExist"};
+	public static final Object[] BALANCE = {"Balance"};
+	public static final Object[] WRITE_TEMP_DATA = {"WriteTempData"};
+	public static final Object[] BALANCE_ADD = {"BalanceAdd"};
+	public static final Object[] BALANCE_REMOVE = {"BalanceRemove"};
+	public static final Object[] BALANCE_SET = {"BalanceSet"};
+	public static final Object[] BALANCE_ADD_ADMIN = {"BalanceAddAdmin"};
+	public static final Object[] BALANCE_REMOVE_ADMIN = {"BalanceRemoveAdmin"};
+	public static final Object[] BALANCE_SET_ADMIN = {"BalanceSetAdmin"};
+	public static final Object[] INVALID_ACCOUNT = {"PayInvalidAccount"};
+	public static final Object[] PAY_SENDER = {"PaySender"};
+	public static final Object[] PAY_RECIPIENT = {"PayRecipient"};
+	public static final Object[] PAY_FAIL = {"PayFail"};
+	public static final Object[] PAY_MISSING_AMOUNT = {"PayMissingAmount"};
+	public static final Object[] PAY_ZERO_OR_BELOW = {"PayZeroOrBelow"};
+	public static final Object[] PAY_SELF = {"PaySelf"};
+
+}

--- a/src/main/java/com/ericgrandt/config/LocaleService.java
+++ b/src/main/java/com/ericgrandt/config/LocaleService.java
@@ -1,0 +1,25 @@
+package com.ericgrandt.config;
+
+import org.spongepowered.api.event.Listener;
+import sawfowl.localeapi.event.LocaleServiseEvent;
+
+public class LocaleService {
+
+    sawfowl.localeapi.api.LocaleService localeService;
+
+    Locales locales;
+
+    public sawfowl.localeapi.api.LocaleService get() {
+        return localeService;
+    }
+
+    void setLocales(Locales locales) {
+        this.locales = locales;
+    }
+
+    @Listener
+    public void getLocaleService(LocaleServiseEvent.Started event) {
+        localeService = event.getLocaleService();
+        locales.generate();
+    }
+}

--- a/src/main/java/com/ericgrandt/config/Locales.java
+++ b/src/main/java/com/ericgrandt/config/Locales.java
@@ -1,0 +1,138 @@
+package com.ericgrandt.config;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.spongepowered.api.event.Listener;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextReplacementConfig;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import sawfowl.localeapi.api.ConfigTypes;
+import sawfowl.localeapi.event.LocaleServiseEvent;
+import sawfowl.localeapi.utils.AbstractLocaleUtil;
+
+public class Locales {
+
+	private LocaleService localeService;
+	private boolean json;
+
+	public Locales() {}
+	public Locales(LocaleService localeService) {
+		this.localeService = localeService;
+		localeService.locales = this;
+	}
+
+	void generate() {
+		localeService.get().createPluginLocale("totaleconomy", ConfigTypes.HOCON, org.spongepowered.api.util.locale.Locales.DEFAULT);
+		localeService.get().createPluginLocale("totaleconomy", ConfigTypes.HOCON, org.spongepowered.api.util.locale.Locales.RU_RU);
+		generateDefault();
+		generateRu();
+	}
+
+	public Map<String, String> createReplaceMap(List<String> keys, List<Object> values) {
+		Map<String, String> map = new HashMap<String, String>();
+		int i = 0;
+		for(String key : keys) {
+			if(i >= keys.size() || i >= values.size()) break;
+			map.put(key, values.get(i).toString());
+			i++;
+		}
+		return map;
+	}
+
+	public Component getText(String defaultText, Locale locale, Object[] path) {
+		if(localeService == null) return toText(defaultText);
+		return getAbstractLocaleUtil(locale).getComponent(json, path);
+	}
+
+	public Component getTextWhithReplacers(String defaultText, Locale locale, Map<String, String> replaceMap, Object[] path) {
+		if(localeService == null) return replace(toText(defaultText), replaceMap);
+		return replace(getAbstractLocaleUtil(locale).getComponent(json, path), replaceMap);
+	}
+
+	private void generateDefault() {
+		Locale locale = org.spongepowered.api.util.locale.Locales.DEFAULT;
+		boolean check = check(locale, toText("&aOnly players can use this command."), null, LocalePaths.ONLY_PLAYER);
+		check = check(locale, toText("That currency does not exist."), null, LocalePaths.CURRENCY_NOT_EXIST) || check;
+		check = check(locale, toText("Player argument is missing."), null, LocalePaths.PLAYER_MISSING) || check;
+		check = check(locale, toText("&aBalance&f: &6" + Placeholders.CURRENCY + Placeholders.BALANCE + "&a."), null, LocalePaths.BALANCE) || check;
+		check = check(locale, toText("&aYour balance in the currency &6" + Placeholders.CURRENCY + " &ais increased by &6" + Placeholders.CURRENCY + Placeholders.VALUE + "&a. Current balance&f: &6" + Placeholders.CURRENCY + Placeholders.BALANCE + "&a."), null, LocalePaths.BALANCE_ADD) || check;
+		check = check(locale, toText("&aYour balance in the currency &6" + Placeholders.CURRENCY + " &ais reduced by &6" + Placeholders.CURRENCY + Placeholders.VALUE + "&a. Current balance&f: &6" + Placeholders.CURRENCY + Placeholders.BALANCE + "&a."), null, LocalePaths.BALANCE_REMOVE) || check;
+		check = check(locale, toText("&aYour balance in the currency &6" + Placeholders.CURRENCY + " &ais set to &6" + Placeholders.CURRENCY + Placeholders.BALANCE + "&a."), null, LocalePaths.BALANCE_SET) || check;
+		check = check(locale, toText("Account not found. Writing temporary data."), null, LocalePaths.WRITE_TEMP_DATA) || check;
+		check = check(locale, toText("Failed to run command: invalid account(s)."), null, LocalePaths.INVALID_ACCOUNT) || check;
+		check = check(locale, toText("&aThe balance of the player &6" + Placeholders.PLAYER + " &aincreased by &6" + Placeholders.CURRENCY + Placeholders.VALUE + "&a. Current balance&f: &6" + Placeholders.CURRENCY + Placeholders.BALANCE + "&a."), null, LocalePaths.BALANCE_ADD_ADMIN) || check;
+		check = check(locale, toText("&aThe balance of the player &6" + Placeholders.PLAYER + " &areduced by &6" + Placeholders.CURRENCY + Placeholders.VALUE + "&a. Current balance&f: &6" + Placeholders.CURRENCY + Placeholders.BALANCE + "&a."), null, LocalePaths.BALANCE_REMOVE_ADMIN) || check;
+		check = check(locale, toText("&aThe balance of the player &6" + Placeholders.PLAYER + " &aset to &6" + Placeholders.CURRENCY + Placeholders.BALANCE + "&a."), null, LocalePaths.BALANCE_SET_ADMIN) || check;
+		check = check(locale, toText("&aYou have sent &6" + Placeholders.CURRENCY + Placeholders.VALUE + " &ato &6" + Placeholders.PLAYER + "&a."), null, LocalePaths.PAY_SENDER) || check;
+		check = check(locale, toText("&aYou have received &6" + Placeholders.CURRENCY + Placeholders.VALUE + " &afrom  &6" + Placeholders.PLAYER + "&a."), null, LocalePaths.PAY_RECIPIENT) || check;
+		check = check(locale, toText("Failed to run command: unable to set balances."), null, LocalePaths.PAY_FAIL) || check;
+		check = check(locale, toText("Amount argument is missing."), null, LocalePaths.PAY_MISSING_AMOUNT) || check;
+		check = check(locale, toText("Amount must be greater than 0."), null, LocalePaths.PAY_ZERO_OR_BELOW) || check;
+		check = check(locale, toText("You cannot pay yourself."), null, LocalePaths.PAY_SELF) || check;
+		if(check) save(locale);
+	}
+
+	private void generateRu() {
+		Locale locale = org.spongepowered.api.util.locale.Locales.RU_RU;
+		boolean check = check(locale, toText("&aТолько игроки могут использовать эту команду."), null, LocalePaths.ONLY_PLAYER);
+		check = check(locale, toText("Не удалось найти указанную валюту."), null, LocalePaths.CURRENCY_NOT_EXIST) || check;
+		check = check(locale, toText("Нужно указать ник игрока."), null, LocalePaths.PLAYER_MISSING) || check;
+		check = check(locale, toText("&aБаланс&f: &6" + Placeholders.CURRENCY + Placeholders.BALANCE + "&a."), null, LocalePaths.BALANCE) || check;
+		check = check(locale, toText("&aВаш баланс в валюте &6" + Placeholders.CURRENCY + " &aувеличен на &6" + Placeholders.CURRENCY + Placeholders.VALUE + "&a. Текущий баланс&f: &6" + Placeholders.CURRENCY + Placeholders.BALANCE + "&a."), null, LocalePaths.BALANCE_ADD) || check;
+		check = check(locale, toText("&aВаш баланс в валюте &6" + Placeholders.CURRENCY + " &aуменьшен на &6" + Placeholders.CURRENCY + Placeholders.VALUE + "&a. Текущий баланс&f: &6" + Placeholders.CURRENCY + Placeholders.BALANCE + "&a."), null, LocalePaths.BALANCE_REMOVE) || check;
+		check = check(locale, toText("&aВаш баланс в валюте &6" + Placeholders.CURRENCY + " &aтеперь равен &6" + Placeholders.CURRENCY + Placeholders.BALANCE + "&a."), null, LocalePaths.BALANCE_SET) || check;
+		check = check(locale, toText("Аккаунт не найден. Запись временных данных."), null, LocalePaths.WRITE_TEMP_DATA) || check;
+		check = check(locale, toText("Не удалось выполнить команду: недействительный счет(а)."), null, LocalePaths.INVALID_ACCOUNT) || check;
+		check = check(locale, toText("&aБаланс игрока &6" + Placeholders.PLAYER + " &aувеличен на &6" + Placeholders.CURRENCY + Placeholders.VALUE + "&a. Текущий баланс&f: &6" + Placeholders.CURRENCY + Placeholders.BALANCE + "&a."), null, LocalePaths.BALANCE_ADD_ADMIN) || check;
+		check = check(locale, toText("&aБаланс игрока &6" + Placeholders.PLAYER + " &aуменьшен на &6" + Placeholders.CURRENCY + Placeholders.VALUE + "&a. Текущий баланс&f: &6" + Placeholders.CURRENCY + Placeholders.BALANCE + "&a."), null, LocalePaths.BALANCE_REMOVE_ADMIN) || check;
+		check = check(locale, toText("&aБаланс игрока &6" + Placeholders.PLAYER + " &aтеперь равен &6" + Placeholders.CURRENCY + Placeholders.BALANCE + "&a."), null, LocalePaths.BALANCE_SET_ADMIN) || check;
+		check = check(locale, toText("&aВы передали &6" + Placeholders.CURRENCY + Placeholders.VALUE + " &aигроку &6" + Placeholders.PLAYER + "&a."), null, LocalePaths.PAY_SENDER) || check;
+		check = check(locale, toText("&aВы получили &6" + Placeholders.CURRENCY + Placeholders.VALUE + " &aот игрока  &6" + Placeholders.PLAYER + "&a."), null, LocalePaths.PAY_RECIPIENT) || check;
+		check = check(locale, toText("Не удалось выполнить команду: невозможно установить баланс."), null, LocalePaths.PAY_FAIL) || check;
+		check = check(locale, toText("Вы не указали сумму."), null, LocalePaths.PAY_MISSING_AMOUNT) || check;
+		check = check(locale, toText("Сумма должна быть больше 0."), null, LocalePaths.PAY_ZERO_OR_BELOW) || check;
+		check = check(locale, toText("Нельзя заплатить самому себе."), null, LocalePaths.PAY_SELF) || check;
+		if(check) save(locale);
+	}
+
+	private Component replace(Component component, Map<String, String> map) {
+		for(Entry<String, String> entry : map.entrySet()) {
+			component = component.replaceText(TextReplacementConfig.builder().match(entry.getKey()).replacement(Component.text(entry.getValue())).build());
+		}
+		return component;
+	}
+
+	private AbstractLocaleUtil getAbstractLocaleUtil(Locale locale) {
+		return localeService.get().getPluginLocales("totaleconomy").containsKey(locale) ? localeService.get().getPluginLocales("totaleconomy").get(locale) : localeService.get().getPluginLocales("totaleconomy").get(org.spongepowered.api.util.locale.Locales.DEFAULT);
+	}
+
+	private Component toText(String string) {
+		return LegacyComponentSerializer.legacyAmpersand().deserialize(string);
+	}
+
+	private boolean check(Locale locale, Component value, String comment, Object... path) {
+		return getAbstractLocaleUtil(locale).checkComponent(json, value, comment, path);
+	}
+
+	private void save(Locale locale) {
+		getAbstractLocaleUtil(locale).saveLocaleNode();
+	}
+
+	public class Placeholders {
+		
+		public static final String PLAYER = "%player%";
+		
+		public static final String BALANCE = "%balance%";
+		
+		public static final String CURRENCY = "%currency%";
+		
+		public static final String VALUE = "%value%";
+		
+	}
+
+}

--- a/src/main/java/com/ericgrandt/data/TempData.java
+++ b/src/main/java/com/ericgrandt/data/TempData.java
@@ -1,0 +1,66 @@
+package com.ericgrandt.data;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.registry.RegistryTypes;
+import org.spongepowered.api.service.economy.Currency;
+import org.spongepowered.configurate.objectmapping.ConfigSerializable;
+import org.spongepowered.configurate.objectmapping.meta.Setting;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+@ConfigSerializable
+public class TempData {
+
+    public TempData(){}
+
+    public TempData(Currency currency, BigDecimal amount) {
+        this.currency = toPlain(currency.displayName());
+        update(amount);
+    }
+    @Setting("Currency")
+    private String currency;
+    @Setting("Amount")
+    private double amount;
+    @Setting
+    private long expire;
+
+    public Currency getCurrency() {
+        Optional<Currency> optionalCurrency = Sponge.game().registry(RegistryTypes.CURRENCY).stream().filter(currency1 -> (toPlain(currency1.displayName()).equals(currency) || toPlain(currency1.displayName()).contains(currency))).findFirst();
+        return optionalCurrency.isPresent() ? optionalCurrency.get() : Sponge.game().registry(RegistryTypes.CURRENCY).stream().filter(currency1 -> (currency1.isDefault())).findFirst().get();
+    }
+
+    public BigDecimal getAmount() {
+        return BigDecimal.valueOf(amount);
+    }
+
+    public boolean isExpire() {
+        return expire <= System.currentTimeMillis();
+    }
+
+    public void update(BigDecimal amount) {
+        this.amount = amount.doubleValue();
+        expire = System.currentTimeMillis() + 432000000l;
+    }
+
+    private String toPlain(Component component) {
+        return LegacyComponentSerializer.legacyAmpersand().serialize(component);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        TempData tempData = (TempData) o;
+
+        return currency.equals(tempData.currency);
+    }
+
+    @Override
+    public int hashCode() {
+        return currency.hashCode();
+    }
+}

--- a/src/main/java/com/ericgrandt/domain/TEAccount.java
+++ b/src/main/java/com/ericgrandt/domain/TEAccount.java
@@ -1,5 +1,6 @@
 package com.ericgrandt.domain;
 
+import com.ericgrandt.TotalEconomy;
 import com.google.common.base.Objects;
 import java.math.BigDecimal;
 import java.util.Map;
@@ -101,6 +102,10 @@ public class TEAccount implements UniqueAccount {
             );
         }
 
+        TotalEconomy.getInstance().getAccountService().getBalances(this.userId).stream().filter(balance -> (balance.getCurrencyId() == ((TECurrency) (currency)).getId())).findFirst().ifPresent(balance -> {
+            balance.setBalance(amount);
+            TotalEconomy.getInstance().getAccountService().getAccountData().setBalance(balance);
+        });
         balances.replace(currency, amount);
 
         return new TETransactionResult(

--- a/src/main/java/com/ericgrandt/player/PlayerListener.java
+++ b/src/main/java/com/ericgrandt/player/PlayerListener.java
@@ -1,9 +1,15 @@
 package com.ericgrandt.player;
 
+import com.ericgrandt.TotalEconomy;
+import com.ericgrandt.data.TempData;
 import com.ericgrandt.services.TEEconomyService;
 import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.entity.living.player.server.ServerPlayer;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.network.ServerSideConnectionEvent;
+
+import java.util.List;
+import java.util.Optional;
 
 public class PlayerListener {
     private final TEEconomyService economyService;
@@ -14,8 +20,16 @@ public class PlayerListener {
 
     @Listener
     public void onPlayerJoin(ServerSideConnectionEvent.Join event) {
-        Player player = event.player();
+        ServerPlayer player = event.player();
 
         economyService.findOrCreateAccount(player.uniqueId());
+        if(player.hasPlayedBefore()) return;
+        Optional<List<TempData>> tempdata = TotalEconomy.getInstance().getDefaultConfiguration().get().getTempData(player.name());
+        if(!tempdata.isPresent()) return;
+        tempdata.get().forEach(temp -> {
+            economyService.findOrCreateAccount(player.uniqueId()).ifPresent(account -> {
+                account.setBalance(temp.getCurrency(), account.balance(temp.getCurrency()).add(temp.getAmount()));
+            });
+        });
     }
 }

--- a/src/main/java/com/ericgrandt/services/AccountService.java
+++ b/src/main/java/com/ericgrandt/services/AccountService.java
@@ -14,6 +14,9 @@ public class AccountService {
         this.accountData = accountData;
     }
 
+    public AccountData getAccountData() {
+        return accountData;
+    }
     public void addAccount(TEAccount account) {
         accountData.addAccount(account);
     }

--- a/src/main/java/com/ericgrandt/wrappers/ParameterWrapper.java
+++ b/src/main/java/com/ericgrandt/wrappers/ParameterWrapper.java
@@ -2,11 +2,15 @@ package com.ericgrandt.wrappers;
 
 import java.math.BigDecimal;
 import org.spongepowered.api.command.parameter.Parameter;
+import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.entity.living.player.server.ServerPlayer;
 
 public class ParameterWrapper {
     public Parameter.Value.Builder<ServerPlayer> player() {
         return Parameter.player();
+    }
+    public Parameter.Value.Builder<String> user() {
+        return Parameter.string();
     }
 
     public Parameter.Value.Builder<BigDecimal> bigDecimal() {

--- a/src/main/resources/schema/mysql.sql
+++ b/src/main/resources/schema/mysql.sql
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS te_currency (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name_singular VARCHAR(50) NOT NULL UNIQUE,
     name_plural VARCHAR(50) NOT NULL UNIQUE,
-    symbol VARCHAR(2) CHARACTER SET UTF8MB4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
+    symbol VARCHAR(2) CHARACTER SET UTF8MB4 COLLATE utf8mb4_unicode_ci NOT NULL,
     num_fraction_digits INT DEFAULT 0 NOT NULL,
     is_default BOOL NOT NULL
 );


### PR DESCRIPTION
1. Fixed bug with unchanged balance.
2. Added administrative commands to change the balance. For the administrative command to deposit a player's balance has been added cache, which for 5 days gets the data that could not be processed. This will replenish the balance of those players who have not yet logged on to the server, but bought game currency (for example on the server site).
Improved the `/pay` command. Now you can specify the currency.
3. Optional support for LocaleAPI has been implemented. The plugin now supports localization. Players will see messages in the language selected in their game client, provided that the plugin has a language config for this language. If no config is found, the default language config will be used. If there is no LocaleAPI plugin, all messages will be in English (this text is entirely in the plugin code).
4. In the process of building the plugin, a driver will be added to connect to the MySQL database. This will avoid errors when trying to establish a connection to the MySQL server.
5. Changed encoding of created tables in the database. Now `utf8mb4_unicode_ci` is used. I did not have the encoding you specified earlier and the database was not created. I have the latest version of MySQL server MariaDB(Btw. I use Arch. :smile: ).

I didn't try to design the code nicely. You're going to want to design it your way anyway.
