### PR TITLE
Remove adventure text from builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Total Economy will be documented in this file.
 
+## [0.13.1] - 2024-08-XX
+
+### Fixed
+
+- Fix an issue with SpongeForge not working due to duplicate dependencies
+
 ## [0.13.0] - 2024-07-20
 
 This update causes a breaking change for custom job rewards. See the "Changed" section below for more information.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Total Economy will be documented in this file.
 
-## [0.13.1] - 2024-08-XX
+## [0.13.1] - 2024-09-08
 
 ### Fixed
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,11 +35,6 @@ subprojects {
             archiveClassifier.set("")
             archiveFileName.set("TotalEconomy-${project.version}.jar")
 
-            mergeServiceFiles()
-
-            // Exclude net.kyori packages to avoid interfering with the one bundled with Sponge
-            exclude("net/kyori/**/*")
-
             minimize {
                 exclude(project(":totaleconomy-common"))
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,12 @@
 plugins {
     id("java-library")
-    id("io.github.goooler.shadow") version "8.1.7"
+    id("com.gradleup.shadow") version "8.3.0"
     checkstyle
 }
 
 subprojects {
     plugins.apply("java-library")
-    plugins.apply("io.github.goooler.shadow")
+    plugins.apply("com.gradleup.shadow")
     plugins.apply("checkstyle")
 
     repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,11 @@ subprojects {
             archiveClassifier.set("")
             archiveFileName.set("TotalEconomy-${project.version}.jar")
 
+            mergeServiceFiles()
+
+            // Exclude net.kyori packages to avoid interfering with the one bundled with Sponge
+            exclude("net/kyori/**/*")
+
             minimize {
                 exclude(project(":totaleconomy-common"))
             }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=0.13.0
+version=0.13.1
 group=com.ericgrandt.totaleconomy

--- a/totaleconomy-bukkit/build.gradle.kts
+++ b/totaleconomy-bukkit/build.gradle.kts
@@ -22,4 +22,11 @@ tasks {
         dependsOn(shadowJar)
         minecraftVersion("1.21")
     }
+
+    shadowJar {
+        mergeServiceFiles()
+
+        // Exclude net.kyori packages to avoid interfering with the one bundled with Paper
+        exclude("net/kyori/**/*")
+    }
 }

--- a/totaleconomy-bukkit/src/main/resources/plugin.yml
+++ b/totaleconomy-bukkit/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: TotalEconomy
-version: 0.13.0
+version: 0.13.1
 main: com.ericgrandt.totaleconomy.TotalEconomy
 description: All in one economy plugin for Minecraft
 author: Eric

--- a/totaleconomy-common/build.gradle.kts
+++ b/totaleconomy-common/build.gradle.kts
@@ -3,6 +3,6 @@ dependencies {
         exclude("org.slf4j", "slf4j-api")
     }
     implementation("org.mybatis:mybatis:3.5.11")
-    implementation("net.kyori:adventure-api:4.15.0")
+    implementation("net.kyori:adventure-api:4.17.0")
     testImplementation("org.assertj:assertj-core:3.25.1")
 }

--- a/totaleconomy-sponge/build.gradle.kts
+++ b/totaleconomy-sponge/build.gradle.kts
@@ -43,5 +43,10 @@ tasks {
         minimize {
             exclude(dependency("com.mysql:mysql-connector-j:.*"))
         }
+
+        mergeServiceFiles()
+
+        // Exclude net.kyori packages to avoid interfering with the one bundled with Sponge
+        exclude("net/kyori/**/*")
     }
 }

--- a/totaleconomy-sponge/build.gradle.kts
+++ b/totaleconomy-sponge/build.gradle.kts
@@ -43,8 +43,5 @@ tasks {
         minimize {
             exclude(dependency("com.mysql:mysql-connector-j:.*"))
         }
-
-        // Exclude net.kyori packages to avoid interfering with the one bundled with Sponge
-        //exclude("net/kyori/**/*")
     }
 }

--- a/totaleconomy-sponge/build.gradle.kts
+++ b/totaleconomy-sponge/build.gradle.kts
@@ -43,5 +43,8 @@ tasks {
         minimize {
             exclude(dependency("com.mysql:mysql-connector-j:.*"))
         }
+
+        // Exclude net.kyori packages to avoid interfering with the one bundled with Sponge
+        //exclude("net/kyori/**/*")
     }
 }


### PR DESCRIPTION
Both Paper and Sponge come with adventure text already, so this PR removes it from the individual plugins to avoid potential errors with conflicting/duplicate libraries.

Fixes #420
Fixes #421 